### PR TITLE
Update output_mixing.md

### DIFF
--- a/doc/output_mixing.md
+++ b/doc/output_mixing.md
@@ -34,10 +34,10 @@ float pitch_command = pidsum[AXIS_PITCH];
 float roll_command = pidsum[AXIS_ROLL];
 float yaw_command = pidsum[AXIS_YAW];
 
-motor_commands[MOTOR_A] = throttle - pitch_command - yaw_command;
-motor_commands[MOTOR_B] = throttle - roll_command + yaw_command;
-motor_commands[MOTOR_C] = throttle + pitch_command - yaw_command;
-motor_commands[MOTOR_D] = throttle + roll_command + yaw_command;
+motor_commands[MOTOR_A] = throttle - pitch_command + yaw_command;
+motor_commands[MOTOR_B] = throttle - roll_command - yaw_command;
+motor_commands[MOTOR_C] = throttle + pitch_command + yaw_command;
+motor_commands[MOTOR_D] = throttle + roll_command - yaw_command;
 ```
 
 As an example if we have a wing setup shown below a potential mixer would look like:


### PR DESCRIPTION
Changed the signs on the Quad Plus setup example.  Yawing to the right creates a positive yaw pidSum, so for a motor spinning CW(Motor A), you'd want to add more power in order to yaw back left.